### PR TITLE
Add support for UIDevice iPad detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Works on both Android and iOS platforms, but **will not pass the Apple App Store
 
 Tested on iOS Simulator devices: iPhone 5, 6, 7, 8, SE, X, XR, XS, XS Max
 
+**NOTE**: Does not return any values for iPad at this time.
+
 ## Installation
 
 In your application project directory:

--- a/src/ios/RSSI.swift
+++ b/src/ios/RSSI.swift
@@ -31,6 +31,7 @@ import Foundation
  * https://stackoverflow.com/a/47566231/943540
  *
  * modelIdentifier:
+ *   iPad Pro: 7,1
  *   iPhone SE: 8,4
  *   iPhone 8: 10,4, 10,5
  *   iPhone X: 10,3 10,6
@@ -51,7 +52,9 @@ extension UIDevice {
             modelIdentifier = String(cString: machine)
         }
 
-        let modelNumber = modelIdentifier.replacingOccurrences(of: "iPhone", with: "")
+        let modelNumber = modelIdentifier
+            .replacingOccurrences(of: "iPhone", with: "")
+            .replacingOccurrences(of: "iPad", with: "")
         let modelArray = modelNumber.components(separatedBy: ",")
         let modelMajor:Int! = Int(modelArray[0])
         let modelMinor:Int! = Int(modelArray[1])


### PR DESCRIPTION
Resolves the crash as reported in https://github.com/emcniece/cordova-plugin-rssi/issues/2, but reveals a bigger problem: iPad doesn't seem to return any values for RSSI out of the private API.

Tracking in https://github.com/emcniece/cordova-plugin-rssi/issues/3