### PR TITLE
Plugin requirement for swift 2.0.1 causes build error.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -39,5 +39,5 @@
         <header-file src="src/ios/OCCatch.h"/>
     </platform>
 
-    <dependency id="cordova-plugin-add-swift-support" version="1.7.2"/>
+    <dependency id="cordova-plugin-add-swift-support" version="2.0.1"/>
 </plugin>


### PR DESCRIPTION
The current 1.7.2 requirement is throwing the following error in my build environment and I can't seem to resolve it.

```
Error - Plugin error (you probably need to remove plugin files from your app): Fetching plugin "cordova-plugin-rssi@^1.1.1" via npm 
Installing "cordova-plugin-rssi" at "1.1.1" for ios Failed to install 'cordova-plugin-rssi': 
CordovaError: Version of installed plugin: "cordova-plugin-add-swift-support@2.0.1" 
does not satisfy dependency plugin requirement "cordova-plugin-add-swift-support@^1.7.2". 
Try --force to use installed plugin as dependency. 
at /usr/local/lib/node_modules/pgb-plugman-151/node_modules/pgb-cordova-lib/src/plugman/install.js:557:37 
at _fulfilled (/usr/local/lib/node_modules/pgb-plugman-151/node_modules/q/q.js:787:54) 
at /usr/local/lib/node_modules/pgb-plugman-151/node_modules/q/q.js:816:30 
at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/pgb-plugman-151/node_modules/q/q.js:749:13) 
at /usr/local/lib/node_modules/pgb-plugman-151/node_modules/q/q.js:509:49 
at flush (/usr/local/lib/node_modules/pgb-plugman-151/node_modules/q/q.js:108:17) 
at process.internalTickCallback (internal/process/next_tick.js:70:11) 
Version of installed plugin: "cordova-plugin-add-swift-support@2.0.1" 
does not satisfy dependency plugin requirement "cordova-plugin-add-swift-support@^1.7.2". 
```

I think if we update the dependency in the plugin.xml that should resolve the issue.