### PR TITLE
v1.1.2: Upgrade cordova swift

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,9 @@ This open-source project was made possible by some fine people over at [CNY Apps
 
 ## Changelog ##
 
+- v1.1.2
+  - Upgrade [cordova-plugin-add-swift-support](https://github.com/akofman/cordova-plugin-add-swift-support) to 2.0.1
+
 - v1.1.1
   - Preventing iPad crash ([#4](https://github.com/emcniece/cordova-plugin-rssi/pull/4))
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-rssi",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Cordova plugin for reading WiFi RSSI",
   "main": "index.js",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-rssi"
-    version="1.1.1">
+    version="1.1.2">
 
     <name>RSSI</name>
     <description>RSSI plugin for Cordova</description>

--- a/src/ios/RSSI.swift
+++ b/src/ios/RSSI.swift
@@ -60,8 +60,8 @@ extension UIDevice {
         let modelMinor:Int! = Int(modelArray[1])
         
         #if DEBUG
-            print("modelIdentifier: \(modelIdentifier)")
-            print("modelArray: \(modelArray)")
+            print("cordova-plugin-rssi: modelIdentifier: \(modelIdentifier)")
+            print("cordova-plugin-rssi: modelArray: \(modelArray)")
         #endif
 
         if modelMajor < 10 {
@@ -103,7 +103,7 @@ extension UIDevice {
         }
         
         #if DEBUG
-            print("RSSI: rssi: \(rssi), bars: \(bars), isIPhoneX: \(isIPhoneX)")
+            print("cordova-plugin-rssi: rssi: \(rssi), bars: \(bars), isIPhoneX: \(isIPhoneX)")
         #endif
 
         let message: NSDictionary = NSDictionary(
@@ -135,7 +135,7 @@ extension UIDevice {
         }
         
         if let exception = exception {
-            print("getWiFiRSSI exception: \(exception)")
+            print("cordova-plugin-rssi: getWiFiRSSI exception: \(exception)")
         }
         
         return rssi
@@ -161,7 +161,7 @@ extension UIDevice {
         }
         
         if let exception = exception {
-            print("getNormalWifiBars exception: \(exception)")
+            print("cordova-plugin-rssi: getNormalWifiBars exception: \(exception)")
         }
         
         return bars
@@ -190,7 +190,7 @@ extension UIDevice {
         }
         
         if let exception = exception {
-            print("getXWifiBars exception: \(exception)")
+            print("cordova-plugin-rssi: getXWifiBars exception: \(exception)")
         }
         
         return bars


### PR DESCRIPTION
- Upgrades `cordova-plugin-add-swift-support` from `1.7.2` to `2.0.1`
- Unifies iOS debug logging for easier pinpointing