### PR TITLE
iOS 13 compatibility refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ rssi.read(function success(data){
 ```
 
 - `rssi`: WiFi Received Signal Strength Indicator
-  - Availability: Android, iOS but not iPhoneX
+  - Availability: Android, iOS 10-12
   - Value: Integer or `null` if unavailable
   - Range: `-100 ≤ x ≤ 0`
 - `bars`: Number of visible bars in WiFi icon
@@ -48,9 +48,6 @@ rssi.read(function success(data){
     - `2`: RSSI `-67` - `-77`
     - `1`: RSSI `-78` - `-88`
     - `0`: RSSI `-89-`
-- `isIPhoneX`: Flag for detecting whether iPhone X acquisition was used
-  - Availability: Android, iOS
-  - Value: Boolean
 
 
 ## Browser / Development Usage
@@ -75,6 +72,11 @@ This open-source project was made possible by some fine people over at [CNY Apps
 [The MIT License](./LICENSE)
 
 ## Changelog ##
+
+- v1.2.0
+  - iOS 13+ compatibility, `bars` detection refactor
+  - Deprecated `isIPhoneX` method
+  - Upgrade [cordova-plugin-add-swift-support](https://github.com/akofman/cordova-plugin-add-swift-support) to 2.0.2
 
 - v1.1.2
   - Upgrade [cordova-plugin-add-swift-support](https://github.com/akofman/cordova-plugin-add-swift-support) to 2.0.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-rssi",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Cordova plugin for reading WiFi RSSI",
   "main": "index.js",
   "scripts": {

--- a/plugin.xml
+++ b/plugin.xml
@@ -39,5 +39,5 @@
         <header-file src="src/ios/OCCatch.h"/>
     </platform>
 
-    <dependency id="cordova-plugin-add-swift-support" version="2.0.1"/>
+    <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
 </plugin>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-plugin-rssi"
-    version="1.1.2">
+    version="1.2.0">
 
     <name>RSSI</name>
     <description>RSSI plugin for Cordova</description>

--- a/src/android/RSSI.java
+++ b/src/android/RSSI.java
@@ -77,7 +77,6 @@ public class RSSI extends CordovaPlugin {
 
                         status.put("rssi", rssi);
                         status.put("bars", level);
-                        status.put("isIPhoneX", false);
 
                         Log.d(TAG, "Sending result: " + status.toString());
 

--- a/src/ios/RSSI.swift
+++ b/src/ios/RSSI.swift
@@ -24,104 +24,63 @@
 
 import Foundation
 
-/*
- * UIDevice Extension
- * Detects iPhoneX devices.
- * Usage: `if UIDevice.isIphoneX {}`
- * https://stackoverflow.com/a/47566231/943540
- *
- * modelIdentifier:
- *   iPad Pro: 7,1
- *   iPhone SE: 8,4
- *   iPhone 8: 10,4, 10,5
- *   iPhone X: 10,3 10,6
- *   iPhone XR: 11,8
- *   iPhone XS: 11,2
- *   iPhone XS Max: 11,4
- */
-extension UIDevice {
-    static var isIphoneX: Bool {
-        var modelIdentifier = ""
-        if isSimulator {
-            modelIdentifier = ProcessInfo.processInfo.environment["SIMULATOR_MODEL_IDENTIFIER"] ?? ""
-        } else {
-            var size = 0
-            sysctlbyname("hw.machine", nil, &size, nil, 0)
-            var machine = [CChar](repeating: 0, count: size)
-            sysctlbyname("hw.machine", &machine, &size, nil, 0)
-            modelIdentifier = String(cString: machine)
+extension UIView {
+    func findStatusBarWifiSignalBars() -> Int? {
+        for view in subviews {
+            if let statusBarWifiSignalView = NSClassFromString("_UIStatusBarWifiSignalView"),
+               view.isKind(of: statusBarWifiSignalView) {
+                // iPhone X
+                return view.value(forKey: "numberOfActiveBars") as? Int
+            } else if let statusBarWifiSignalView = NSClassFromString("UIStatusBarDataNetworkItemView"),
+                      view.isKind(of: statusBarWifiSignalView) {
+                // iPhone non-X
+                return view.value(forKey: "wifiStrengthBars") as? Int
+            } else if let nestedBars = view.findStatusBarWifiSignalBars() {
+                return nestedBars
+            }
         }
-
-        let modelNumber = modelIdentifier
-            .replacingOccurrences(of: "iPhone", with: "")
-            .replacingOccurrences(of: "iPad", with: "")
-        let modelArray = modelNumber.components(separatedBy: ",")
-        let modelMajor:Int! = Int(modelArray[0])
-        let modelMinor:Int! = Int(modelArray[1])
-        
-        #if DEBUG
-            print("cordova-plugin-rssi: modelIdentifier: \(modelIdentifier)")
-            print("cordova-plugin-rssi: modelArray: \(modelArray)")
-        #endif
-
-        if modelMajor < 10 {
-            // iPhone 7 and below
-            return false
-        } else if modelMajor == 10 && modelMinor == 3 {
-            // iPhone X, but not iPhone 8
-            return true
-        } else if modelMajor == 10 && modelMinor == 6 {
-            // iPhone X, but not iPhone 8
-            return true
-        } else if modelMajor > 10 {
-            // iPhone XR, XS, XS Max, and above
-            return true
-        } else {
-            // Unknown
-            return false
-        }
-    }
-    
-    static var isSimulator: Bool {
-        return TARGET_OS_SIMULATOR != 0
+        return nil
     }
 }
 
 @objc(RSSI) public class RSSI : CDVPlugin  {
+    @objc(read:)
     public func read(_ command: CDVInvokedUrlCommand) {
-        var rssi: Any
-        var bars: Int!
-        var isIPhoneX: Bool! = false
-        
-        if UIDevice.isIphoneX {
-            isIPhoneX = true
-            rssi = NSNull() // No method for obtaining RSSI on iPhoneX
-            bars = self.getXWifiBars()
-        } else {
-            rssi = self.getNormalWifiRSSI() as Any
-            bars = self.getNormalWifiBars()
-        }
-        
-        #if DEBUG
-            print("cordova-plugin-rssi: rssi: \(rssi), bars: \(bars), isIPhoneX: \(isIPhoneX)")
-        #endif
+        DispatchQueue.global(qos: .background).async {
+            DispatchQueue.main.async {
+                var rssi: Any
+                var bars: Int!
+                
+                if #available(iOS 13.0, *) {
+                    rssi = NSNull() // No method for obtaining RSSI on iOS 13+
+                } else {
+                    rssi = self.getWifiRSSI() as Any
+                }
+                
+                bars = self.getWifiBars()
+                
+                #if DEBUG
+                    print("cordova-plugin-rssi: rssi: \(rssi), bars: \(bars)")
+                #endif
 
-        let message: NSDictionary = NSDictionary(
-            objects: [rssi, bars, isIPhoneX],
-            forKeys: ["rssi" as NSCopying, "bars" as NSCopying, "isIPhoneX" as NSCopying]
-        )
-        
-        let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: message as! [AnyHashable: Any])
-        self.commandDelegate?.send(pluginResult, callbackId: command.callbackId)
+                let message: NSDictionary = NSDictionary(
+                    objects: [rssi, bars],
+                    forKeys: ["rssi" as NSCopying, "bars" as NSCopying]
+                )
+                
+                let pluginResult = CDVPluginResult(status: CDVCommandStatus_OK, messageAs: message as? [AnyHashable: Any])
+                self.commandDelegate?.send(pluginResult, callbackId: command.callbackId)
+            }
+        }
     }
     
-    private func getNormalWifiRSSI() -> Int? {
+    private func getWifiRSSI() -> Int? {
         let app = UIApplication.shared
         var rssi: Int?
         
         let exception = tryBlock {
             guard let statusBar = app.value(forKey: "statusBar") as? UIView else { return }
-            if let statusBarMorden = NSClassFromString("UIStatusBar_Modern"), statusBar .isKind(of: statusBarMorden) { return }
+            if let statusBarModern = NSClassFromString("UIStatusBar_Modern"), statusBar .isKind(of: statusBarModern) { return }
             guard let foregroundView = statusBar.value(forKey: "foregroundView") as? UIView else { return  }
             
             for view in foregroundView.subviews {
@@ -141,56 +100,27 @@ extension UIDevice {
         return rssi
     }
     
-    private func getNormalWifiBars() -> Int? {
-        let app = UIApplication.shared
+    private func getWifiBars() -> Int? {
         var bars: Int?
-        
         let exception = tryBlock {
-            guard let statusBar = app.value(forKey: "statusBar") as? UIView else { return }
-            if let statusBarMorden = NSClassFromString("UIStatusBar_Modern"), statusBar .isKind(of: statusBarMorden) { return }
-            guard let foregroundView = statusBar.value(forKey: "foregroundView") as? UIView else { return  }
-            
-            for view in foregroundView.subviews {
-                if let statusBarDataNetworkItemView = NSClassFromString("UIStatusBarDataNetworkItemView"), view .isKind(of: statusBarDataNetworkItemView) {
-                    if let val = view.value(forKey: "wifiStrengthBars") as? Int {
-                        bars = val
-                        break
-                    }
+            if #available(iOS 13.0, *) {
+                if let statusBarManager = UIApplication.shared.keyWindow?.windowScene?.statusBarManager,
+                    let localStatusBar = statusBarManager.value(forKey: "createLocalStatusBar") as? NSObject,
+                    let statusBar = localStatusBar.value(forKey: "statusBar") as? NSObject,
+                    let _statusBar = statusBar.value(forKey: "_statusBar") as? UIView,
+                    let currentData = _statusBar.value(forKey: "currentData")  as? NSObject,
+                    let wifi = currentData.value(forKey: "wifiEntry") as? NSObject,
+                    let signalStrength = wifi.value(forKey: "displayValue") as? Int {
+                    bars = signalStrength
                 }
+            } else {
+                let statusBarView = UIApplication.shared.value(forKey: "statusBar") as! UIView
+                bars = statusBarView.findStatusBarWifiSignalBars()
             }
         }
         
         if let exception = exception {
-            print("cordova-plugin-rssi: getNormalWifiBars exception: \(exception)")
-        }
-        
-        return bars
-    }
-    
-    private func getXWifiBars() -> Int? {
-        let app = UIApplication.shared
-        var bars: Int?
-        
-        let exception = tryBlock {
-            guard let containerBar = app.value(forKey: "statusBar") as? UIView else { return }
-            guard let statusBarMorden = NSClassFromString("UIStatusBar_Modern"), containerBar .isKind(of: statusBarMorden) else { return }
-            guard let statusBar = containerBar.value(forKey: "statusBar") as? UIView else { return }
-            guard let foregroundView = statusBar.value(forKey: "foregroundView") as? UIView else { return }
-            
-            for view in foregroundView.subviews {
-                for v in view.subviews {
-                    if let statusBarWifiSignalView = NSClassFromString("_UIStatusBarWifiSignalView"), v .isKind(of: statusBarWifiSignalView) {
-                        if let val = v.value(forKey: "numberOfActiveBars") as? Int {
-                            bars = val
-                            break
-                        }
-                    }
-                }
-            }
-        }
-        
-        if let exception = exception {
-            print("cordova-plugin-rssi: getXWifiBars exception: \(exception)")
+            print("cordova-plugin-rssi: getWifiBars exception: \(exception)")
         }
         
         return bars


### PR DESCRIPTION
This PR resolves https://github.com/emcniece/cordova-plugin-rssi/issues/8 with a caveat: RSSI is no longer available for iPhone X/XR/XS for iOS 11+, and for all other devices for iOS 13+. Instead these devices only return the number of bars visible in the wifi icon.

Prior to the implementation of the code in master branch it was thought that iPhone X devices had a unique element tree. Now it is apparent that iPhone X iOS 11-12 was a transition toward iOS 13, and _all_ iOS 13+ devices use a compatible UIView tree. iPhone X for iOS 11-12 remains an edge case.

The `getWifiBars()` method is currently split into 2 blocks: the first for handling non-iPhone X/XR/XS (iOS 11-12), and the second for handling iPhone X/XR/XS. Neither block works on both groups. Ideally this can be executed with some logic to detect the `UIView` elements present and return `bars` for either device group.

An attempt to implement Mirror/reflection on the UIView objects failed. I hoped that by doing this the method could iterate over available view keys and conditionally handle the different devices. The two object extensions remain commented out at the top of this file in case this ends up being useful.

Todo:

- [x] Make it work on all platforms without thrown exceptions
- [x] Deprecate & remove the `isIphoneX` return value
- [x] Update README & changelog